### PR TITLE
fix (show delta): fix and extend show delta functionality

### DIFF
--- a/app/src/main/java/org/fe57/atomspectra/AtomSpectraService.java
+++ b/app/src/main/java/org/fe57/atomspectra/AtomSpectraService.java
@@ -1277,6 +1277,7 @@ public class AtomSpectraService extends Service {
         canOpenAudio = false;
         isRecording = false;
         isStarted = false;
+        showDelta = false;
 
         Log.d(TAG, "recording Stop");
         releaseAR();

--- a/app/src/main/java/org/fe57/atomspectra/AtomSpectraSettings.java
+++ b/app/src/main/java/org/fe57/atomspectra/AtomSpectraSettings.java
@@ -1468,7 +1468,9 @@ public class AtomSpectraSettings extends Activity  implements OnGestureListener,
         SharedPreferences settings = getSharedPreferences(Constants.ATOMSPECTRA_PREFERENCES, MODE_PRIVATE);
         int r = settings.getInt(Constants.CONFIG.CONF_DELTA_TIME, Constants.DEFAULT_DELTA_TIME);
 
-        if (r > 1) {
+        if (r > 10) {
+            r = r - 5;
+        } else if (r > 1) {
             r = r - 1;
         } else {
             r = 1;
@@ -1489,8 +1491,10 @@ public class AtomSpectraSettings extends Activity  implements OnGestureListener,
 
         if (r < 10) {
             r = r + 1;
+        } else if (r < 60) {
+            r = r + 5;
         } else {
-            r = 10;
+            r = 60;
         }
 
         SharedPreferences.Editor prefEditor = settings.edit();


### PR DESCRIPTION
fix scenario:
1) run app
2) enable "Spectrum change" function
3) exit app
4) run app
actual: "Spectrum change" unchecked, app shows delta spectrums 
expected: "Spectrum change" unchecked, app shows normal spectrum

extend setting range up to 60 seconds