### PR TITLE
fix (dose-rate): fix issues with dose rate

### DIFF
--- a/app/src/main/java/org/fe57/atomspectra/AtomSpectra.java
+++ b/app/src/main/java/org/fe57/atomspectra/AtomSpectra.java
@@ -4023,7 +4023,7 @@ public class AtomSpectra extends Activity implements OnGestureListener, OnReques
 				Toast.makeText(this, getString(R.string.device_load_error), Toast.LENGTH_LONG).show();
 				return;
 			}
-			int tempSensG = Constants.MinMax(Integer.parseInt(fr.readLine()), 0, 100000);
+			int tempSensG = Constants.MinMax(Integer.parseInt(fr.readLine()), 0, 1000000);
 			int tempBack = Constants.MinMax(Integer.parseInt(fr.readLine()), 0, 100000);
 			int tempFast = Constants.MinMax(Integer.parseInt(fr.readLine()), 10, 100000);
 			int tempMedium = Constants.MinMax(Integer.parseInt(fr.readLine()), 10, 100000);

--- a/app/src/main/java/org/fe57/atomspectra/AtomSpectraService.java
+++ b/app/src/main/java/org/fe57/atomspectra/AtomSpectraService.java
@@ -1461,6 +1461,10 @@ public class AtomSpectraService extends Service {
             }
         }
         double weightSensG = 7 * 0.88 * 1.0e-2 * 3600 / SensG;
+        // fix sensitivity issue for pro devices (required x10 value comparing to audio spectrometer of the same size)
+        // calculation code was written taking into account that it is called each 0.1 second (sensitivity is set for fixed 0.1 sec interval)
+        // adjust according to actual elapsed time
+        weightSensG /= time / (Constants.UPDATE_PERIOD / 1000.0);
         double hist_dose_e = sumEnergy / accumulated * 4.3 * weightSensG;
         double hist_dose = StrictMath.max(0.0, ((sum / accumulated) - backgroundCount) * weightSensG);
         synchronized (doseHistory) {

--- a/app/src/main/java/org/fe57/atomspectra/AtomSpectraShapeView.java
+++ b/app/src/main/java/org/fe57/atomspectra/AtomSpectraShapeView.java
@@ -773,7 +773,7 @@ public class AtomSpectraShapeView extends View {
 				System.arraycopy(back, 0, back_yf, 0, size);
 			}
 		}
-		if (xZoom_factor == Constants.SCALE_COUNT_MODE) {
+		if (xZoom_factor == Constants.SCALE_COUNT_MODE || xZoom_factor == Constants.SCALE_DOSE_MODE) {
 			xSize = size;
 		}
 


### PR DESCRIPTION
- fix gamma coeff for pro devices (required x10 value comparing to audio of the same size)
- fix 'up/down jumping' of dose rate plot when channel reducton was set in settings
- increase upper limit for sensitivity when reading device from file